### PR TITLE
Replace Updater with CLI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ dependencies {
 }
 
 buildConfig {
-  appName = 'ODK Aggregate Updater'
+  appName = 'ODK Aggregate CLI'
   version = getVersionName()
   clsName = 'BuildConfig'
   packageName = 'org.opendatakit.briefcase.buildconfig'
@@ -57,7 +57,7 @@ buildConfig {
 
 jar {
   manifest {
-    attributes "Main-Class": "org.opendatakit.aggregateupdater.Launcher"
+    attributes "Main-Class": "org.opendatakit.aggregate.cli.Launcher"
   }
 
   from {
@@ -65,8 +65,8 @@ jar {
   }
 
   doLast {
-    makeExecutableJar("${buildDir}/libs/${archivesBaseName}-${version}.jar", "${buildDir}/libs/aggregate-updater")
-    zip("${buildDir}/libs/aggregate-updater")
+    makeExecutableJar("${buildDir}/libs/${archivesBaseName}-${version}.jar", "${buildDir}/libs/aggregate-cli")
+    zip("${buildDir}/libs/aggregate-cli")
   }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
-rootProject.name = 'ODK-Aggregate-Updater'
+rootProject.name = 'ODK-Aggregate-CLI'
 

--- a/src/main/java/org/opendatakit/aggregate/cli/operations/Install.java
+++ b/src/main/java/org/opendatakit/aggregate/cli/operations/Install.java
@@ -47,7 +47,7 @@ final class Install {
   }
 
   private static void deploy(Console console, EnvironmentConfiguration conf, String warUrl) {
-    Path tmpDir = createTempDirectory("aggregate-updater");
+    Path tmpDir = createTempDirectory("aggregate-cli");
     Path tmpAggregateWar = tmpDir.resolve("aggregate.war");
     console.execute(format("wget -O %s %s", tmpAggregateWar, warUrl));
     console.execute(format("unzip -qq %s -d %s", tmpAggregateWar, conf.getRootWebappPath()));


### PR DESCRIPTION
Could not get the app to launch (especially for downstream scripts) without these changes. If this looks good, we should merge and release v1.0.1.